### PR TITLE
Support arbitrary stream merges

### DIFF
--- a/youtube_dlc/extractor/dispeak.py
+++ b/youtube_dlc/extractor/dispeak.py
@@ -93,6 +93,7 @@ class DigitallySpeakingIE(InfoExtractor):
             'quality': -2,
             'preference': -2,
             'format_id': 'slides',
+            'acodec': 'none',
         })
         speaker_video_path = xpath_text(metadata, './speakerVideo', fatal=True)
         formats.append({

--- a/youtube_dlc/postprocessor/ffmpeg.py
+++ b/youtube_dlc/postprocessor/ffmpeg.py
@@ -476,7 +476,7 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
         filename = info['filepath']
         temp_filename = prepend_extension(filename, 'temp')
         in_filenames = [filename]
-        options = []
+        options = ['-map', '0']
 
         if info['ext'] == 'm4a':
             options.extend(['-vn', '-acodec', 'copy'])
@@ -518,7 +518,12 @@ class FFmpegMergerPP(FFmpegPostProcessor):
     def run(self, info):
         filename = info['filepath']
         temp_filename = prepend_extension(filename, 'temp')
-        args = ['-c', 'copy', '-map', '0:v:0', '-map', '1:a:0']
+        args = ['-c', 'copy']
+        for (i, fmt) in enumerate(info['requested_formats']):
+            if fmt.get('acodec') != 'none':
+                args.extend(['-map', '%u:a:0' % (i)])
+            if fmt.get('vcodec') != 'none':
+                args.extend(['-map', '%u:v:0' % (i)])
         self._downloader.to_screen('[ffmpeg] Merging formats into "%s"' % filename)
         self.run_ffmpeg_multiple_files(info['__files_to_merge'], temp_filename, args)
         os.rename(encodeFilename(temp_filename), encodeFilename(filename))


### PR DESCRIPTION
Description cribbed from ytdl-org/youtube-dl#6454.

----

This supersedes ytdl-org/youtube-dl#5581 and ytdl-org/youtube-dl#6435.

With this change, the merge operator may join any number of media streams, video or audio. The streams are downloaded in the order specified.

Use case:

```
youtube-dl http://www.gdcvault.com/play/1014631/Classic-Game-Postmortem-PAC -f speaker+slides+en
```

shall download the `slides` (video only), `speaker` (video+audio) and `en` (audio only) streams and merge them into a single file.

Remarks:
- If more than one video or audio streams are to be merged, the default output format is set to `mkv`. This isn't always necessary: `webm`, `ogg` and `mp4` will do fine with multiple audio and/or video streams; `flv`, on the other hand, will not (and possibly others).
- The metadata for a stream of a particular type are copied into the `info_dict` of the merged stream only if there is a single stream of that type (i.e. only one audio stream and only one video stream). This seems sensible (after all, questions like "what is the audio codec of `bestaudio[acodec=opus]+bestaudio[acodec=vorbis]`" are somewhat ill-formed), but other behaviours might be preferable here (e.g. copying the metadata of the "best-quality" stream of a given type, or copying them if they are the same for every stream and leaving them otherwise, or creating a list of all the values for all the streams).

----

Good luck with the fork, by the way.